### PR TITLE
Added parameter "AllDriveItems"

### DIFF
--- a/GMGoogleDrive/Public/Find-GDriveItem.ps1
+++ b/GMGoogleDrive/Public/Find-GDriveItem.ps1
@@ -38,6 +38,9 @@ param(
     [Parameter(Position=0)]
     [string]$Query,
 
+    [parameter(Mandatory=$false)]
+    [switch]$AllDriveItems,
+    
     [Parameter(ParameterSetName='All')]
     [switch]$AllResults,
 
@@ -57,10 +60,7 @@ param(
     [int]$PageSize = 100,
 
     [Parameter(Mandatory)]
-    [string]$AccessToken,
-
-    [parameter(Mandatory=$false)]
-    [switch]$AllDriveItems
+    [string]$AccessToken
 
 )
 

--- a/GMGoogleDrive/Public/Find-GDriveItem.ps1
+++ b/GMGoogleDrive/Public/Find-GDriveItem.ps1
@@ -7,6 +7,8 @@
     Search Query
 .PARAMETER AllResults
     Collect all results in one output
+.PARAMETER AllDriveItems
+    Get result from all drives (inluding shared drives)
 .PARAMETER OrderBy
     Set output order
 .PARAMETER NextPageToken
@@ -19,6 +21,8 @@
     Find-GDriveItem -AccessToken $access_token -Query 'name contains "test"'
 .EXAMPLE
     Find-GDriveItem -AccessToken $access_token -Query 'name contains "test"' -AllResults
+.EXAMPLE
+    Find-GDriveItem -AccessToken $access_token -Query 'name contains "shareddrivetest"' -AllResults -AllDriveItems
 .OUTPUTS
     Json search result with items metadata as PSObject
 .NOTES
@@ -53,7 +57,11 @@ param(
     [int]$PageSize = 100,
 
     [Parameter(Mandatory)]
-    [string]$AccessToken
+    [string]$AccessToken,
+
+    [parameter(Mandatory=$false)]
+    [switch]$AllDriveItems
+
 )
 
     $Headers = @{
@@ -62,6 +70,9 @@ param(
     Write-Verbose "URI: $GDriveUri"
     $Params = New-Object System.Collections.ArrayList
     [void]$Params.Add('pageSize=' + $PageSize)
+    if ($AllDriveItems) {
+        [void]$Params.Add('includeItemsFromAllDrives=true')
+    }
     if ($Query) {
         [void]$Params.Add('q=' + $Query)
     }

--- a/GMGoogleDrive/Public/Find-GDriveItem.ps1
+++ b/GMGoogleDrive/Public/Find-GDriveItem.ps1
@@ -5,10 +5,10 @@
     Search GoogleDriver for items with specified Query
 .PARAMETER Query
     Search Query
-.PARAMETER AllResults
-    Collect all results in one output
 .PARAMETER AllDriveItems
     Get result from all drives (inluding shared drives)
+.PARAMETER AllResults
+    Collect all results in one output
 .PARAMETER OrderBy
     Set output order
 .PARAMETER NextPageToken
@@ -40,7 +40,7 @@ param(
 
     [parameter(Mandatory=$false)]
     [switch]$AllDriveItems,
-    
+
     [Parameter(ParameterSetName='All')]
     [switch]$AllResults,
 


### PR DESCRIPTION
Thank you for a lovely utility. This saved me many hours :).
I hade problems searching for files on our shared drives, and discovered that I could locate them if I added  "includeItemsFromAllDrives=true" directive to the uri parameters.
I've updated the code with the function parameter "AllDriveItems" which will add this to the Uri when the parameter is set.

Example:
Find-GDriveItem -AccessToken $access_token -Query 'name contains "test"' -AllResults -AllDriveItems