### PR TITLE
added new parameter to Add-GDriveItem and Set-GDriveItemContent

### DIFF
--- a/GMGoogleDrive/Public/Add-GDriveItem.ps1
+++ b/GMGoogleDrive/Public/Add-GDriveItem.ps1
@@ -23,6 +23,8 @@
     Upload request size
 .PARAMETER ShowProgress
     Show progress bar while uploading
+.PARAMETER UseMetadataFromFile
+    Uses the metadata of the file provided in InFile
 .PARAMETER AccessToken
     Access Token for request
 .EXAMPLE
@@ -63,6 +65,7 @@ function Add-GDriveItem {
 
         [Parameter(Mandatory, ParameterSetName='fileName')]
         [Parameter(Mandatory, ParameterSetName='fileMeta')]
+        [Parameter(Mandatory, ParameterSetName='fileAutomaticMeta')]
         [string]$InFile,
 
         [Parameter(Mandatory, ParameterSetName='dataName')]
@@ -73,6 +76,7 @@ function Add-GDriveItem {
         [Parameter(ParameterSetName='dataName')]
         [Parameter(ParameterSetName='stringName')]
         [Parameter(ParameterSetName='fileName')]
+        [Parameter(ParameterSetName='fileAutomaticMeta')]
         [string[]]$ParentID = @('root'),
 
         [Parameter(ParameterSetName='dataMeta')]
@@ -89,6 +93,9 @@ function Add-GDriveItem {
         [int]$ChunkSize = 4Mb,
 
         [switch]$ShowProgress,
+
+        [Parameter(Mandatory, ParameterSetName='fileAutomaticMeta')]
+        [switch]$UseMetadataFromFile,
 
         [Parameter(Mandatory)]
         [string]$AccessToken

--- a/GMGoogleDrive/Public/Add-GDriveItem.ps1
+++ b/GMGoogleDrive/Public/Add-GDriveItem.ps1
@@ -17,7 +17,7 @@
     Folder ID in which new item will be placed
 .PARAMETER JsonProperty
     Json-formatted string with all needed file metadata
-.PARAMETER ResultProperty
+.PARAMETER Property
     List of properties that will be retured once upload is completed
 .PARAMETER ContentType
     Uploaded item Content type (seems google automatically set it to most of uploaded files)
@@ -99,7 +99,7 @@ function Add-GDriveItem {
         'modifiedByMe','trashingUser','trashedTime','teamDriveId','hasAugmentedPermissions',
         'keepForever', 'published', # revisions
         IgnoreCase = $false)]
-        [string[]]$ResultProperty = @('kind','id','name','mimeType','parents'),
+        [string[]]$Property = @('kind','id','name','mimeType','parents'),
 
         [string]$ContentType = 'application/octet-stream',
 

--- a/GMGoogleDrive/Public/Add-GDriveItem.ps1
+++ b/GMGoogleDrive/Public/Add-GDriveItem.ps1
@@ -85,6 +85,18 @@ function Add-GDriveItem {
         [Alias('Metadata')]
         [string]$JsonProperty = '',
 
+        [ValidateSet("*",'kind','id','name','mimeType',
+        'description','starred','trashed','explicitlyTrashed','parents','properties','appProperties','spaces','version',
+        'webContentLink','webViewLink','iconLink','thumbnailLink','viewedByMe','viewedByMeTime','createdTime','modifiedTime',
+        'modifiedByMeTime','sharedWithMeTime','sharingUser','owners','lastModifyingUser','shared','ownedByMe',
+        'viewersCanCopyContent','writersCanShare','permissions','originalFilename','fullFileExtension',
+        'fileExtension','md5Checksum','sha1Checksum','sha256Checksum','size','quotaBytesUsed','headRevisionId','contentHints',
+        'imageMediaMetadata','videoMediaMetadata','capabilities','isAppAuthorized','hasThumbnail','thumbnailVersion',
+        'modifiedByMe','trashingUser','trashedTime','teamDriveId','hasAugmentedPermissions',
+        'keepForever', 'published', # revisions
+        IgnoreCase = $false)]
+        [string[]]$ResultProperty = @('kind','id','name','mimeType','parents'),
+
         [string]$ContentType = 'application/octet-stream',
 
         [ValidateScript({
@@ -96,6 +108,8 @@ function Add-GDriveItem {
 
         [Parameter(Mandatory, ParameterSetName='fileAutomaticMeta')]
         [switch]$UseMetadataFromFile,
+
+        [switch]$KeepRevisionForever,
 
         [Parameter(Mandatory)]
         [string]$AccessToken

--- a/GMGoogleDrive/Public/Add-GDriveItem.ps1
+++ b/GMGoogleDrive/Public/Add-GDriveItem.ps1
@@ -17,6 +17,8 @@
     Folder ID in which new item will be placed
 .PARAMETER JsonProperty
     Json-formatted string with all needed file metadata
+.PARAMETER ResultProperty
+    List of properties that will be retured once upload is completed
 .PARAMETER ContentType
     Uploaded item Content type (seems google automatically set it to most of uploaded files)
 .PARAMETER ChunkSize
@@ -25,6 +27,8 @@
     Show progress bar while uploading
 .PARAMETER UseMetadataFromFile
     Uses the metadata of the file provided in InFile
+.PARAMETER KeepRevisionForever
+    Set the flag that this revision of the file will be kept forever.
 .PARAMETER AccessToken
     Access Token for request
 .EXAMPLE

--- a/GMGoogleDrive/Public/Find-GDriveItem.ps1
+++ b/GMGoogleDrive/Public/Find-GDriveItem.ps1
@@ -48,7 +48,7 @@ param(
     'webContentLink','webViewLink','iconLink','thumbnailLink','viewedByMe','viewedByMeTime','createdTime','modifiedTime',
     'modifiedByMeTime','sharedWithMeTime','sharingUser','owners','lastModifyingUser','shared','ownedByMe',
     'viewersCanCopyContent','writersCanShare','permissions','folderColorRgb','originalFilename','fullFileExtension',
-    'fileExtension','md5Checksum','size','quotaBytesUsed','headRevisionId','contentHints',
+    'fileExtension','md5Checksum','sha256Checksum','sha1Checksum','size','quotaBytesUsed','headRevisionId','contentHints',
     'imageMediaMetadata','videoMediaMetadata','capabilities','isAppAuthorized','hasThumbnail','thumbnailVersion',
     'modifiedByMe','trashingUser','trashedTime','teamDriveId','hasAugmentedPermissions',
     'keepForever', 'published', # revisions
@@ -90,7 +90,7 @@ param(
         [void]$Params.Add('includeItemsFromAllDrives=true')
     }
     if ($Query) {
-        [void]$Params.Add('q=' + $Query)
+        [void]$Params.Add('q=' + [URI]::EscapeDataString($Query) )
     }
     if ($NextPageToken) {
         [void]$Params.Add('pageToken=' + $NextPageToken)

--- a/GMGoogleDrive/Public/New-GDriveFolder.ps1
+++ b/GMGoogleDrive/Public/New-GDriveFolder.ps1
@@ -30,6 +30,8 @@ param(
     [Parameter(Position=1)]
     [string[]]$ParentID = @('root'),
 
+    [DateTime]$CreationDate,
+
     [Parameter(Mandatory)]
     [string]$AccessToken
 )
@@ -44,6 +46,11 @@ param(
         parents = $ParentID
         shortcutDetails = @{ targetId = $TargetID }
     }
+    if($CreationDate) {
+        $Body["createdTime"] = (Get-Date $CreationDate  -Format "yyyy-MM-ddTHH:mm:ss.fffzzz" -AsUTC)
+        $Body["modifiedTime"] = $Body["createdTime"]
+    }
+
     $JsonProperty = ConvertTo-Json $Body -Compress
     Write-Verbose "RequestBody: $JsonProperty"
     if ($PSCmdlet.ShouldProcess("Create new folder $Name")) {

--- a/GMGoogleDrive/Public/New-GDriveFolder.ps1
+++ b/GMGoogleDrive/Public/New-GDriveFolder.ps1
@@ -7,6 +7,8 @@
     Name of an folder item to be created
 .PARAMETER ParentID
     Folder ID(s) in which new item will be placed
+.PARAMETER CreationDate
+    Set the creation date of the new folder in Google Drive
 .PARAMETER AccessToken
     Access Token for request
 .EXAMPLE

--- a/GMGoogleDrive/Public/New-GDriveFolder.ps1
+++ b/GMGoogleDrive/Public/New-GDriveFolder.ps1
@@ -7,8 +7,8 @@
     Name of an folder item to be created
 .PARAMETER ParentID
     Folder ID(s) in which new item will be placed
-.PARAMETER CreationDate
-    Set the creation date of the new folder in Google Drive
+.PARAMETER DateTimeMeta
+    Set the creation date and modification date of the new folder in Google Drive
 .PARAMETER AccessToken
     Access Token for request
 .EXAMPLE
@@ -32,7 +32,7 @@ param(
     [Parameter(Position=1)]
     [string[]]$ParentID = @('root'),
 
-    [DateTime]$CreationDate,
+    [DateTime]$DateTimeMeta,
 
     [Parameter(Mandatory)]
     [string]$AccessToken
@@ -48,8 +48,8 @@ param(
         parents = $ParentID
         shortcutDetails = @{ targetId = $TargetID }
     }
-    if($CreationDate) {
-        $Body["createdTime"] = (Get-Date $CreationDate  -Format "yyyy-MM-ddTHH:mm:ss.fffzzz" -AsUTC)
+    if($DateTimeMeta) {
+        $Body["createdTime"] = (Get-Date $DateTimeMeta  -Format "yyyy-MM-ddTHH:mm:ss.fffzzz" -AsUTC)
         $Body["modifiedTime"] = $Body["createdTime"]
     }
 

--- a/GMGoogleDrive/Public/Set-GDriveItemContent.ps1
+++ b/GMGoogleDrive/Public/Set-GDriveItemContent.ps1
@@ -21,6 +21,8 @@
     Folder ID(s) in which new item will be placed
 .PARAMETER JsonProperty
     Json-formatted string with all needed file metadata
+.PARAMETER ResultProperty
+    List of properties that will be retured once upload is completed
 .PARAMETER ResumeID
     Upload ID to resume operations in case of uploading errors
 .PARAMETER ContentType
@@ -29,6 +31,10 @@
     Upload request size
 .PARAMETER ShowProgress
     Show progress bar while uploading
+.PARAMETER UseMetadataFromFile
+    Uses the metadata of the file provided in InFile
+.PARAMETER KeepRevisionForever
+    Set the flag that this revision of the file will be kept forever.
 .PARAMETER AccessToken
     Access Token for request
 .EXAMPLE

--- a/GMGoogleDrive/Public/Set-GDriveItemContent.ps1
+++ b/GMGoogleDrive/Public/Set-GDriveItemContent.ps1
@@ -282,7 +282,12 @@ function Set-GDriveItemContent {
                         ))
                     {
                         Write-Verbose 'Single request upload'
-                        $WebRequestParams.Body = $RawContent
+                        [byte[]]$buffer = New-Object byte[] $stream.Length
+                        $len = $stream.Read($buffer, 0, $stream.Length);
+                        if ($len -ne $stream.Length) {
+                            throw "Stream read error: Readed $len bytes instead of $($stream.Length)"
+                        }
+                        $WebRequestParams.Body = $buffer
 
                         Write-Verbose ("Content-Length: {0}" -f $stream.Length)
                         if ($ShowProgress) {

--- a/GMGoogleDrive/Public/Set-GDriveItemContent.ps1
+++ b/GMGoogleDrive/Public/Set-GDriveItemContent.ps1
@@ -21,7 +21,7 @@
     Folder ID(s) in which new item will be placed
 .PARAMETER JsonProperty
     Json-formatted string with all needed file metadata
-.PARAMETER ResultProperty
+.PARAMETER Property
     List of properties that will be retured once upload is completed
 .PARAMETER ResumeID
     Upload ID to resume operations in case of uploading errors
@@ -124,7 +124,7 @@ function Set-GDriveItemContent {
         'modifiedByMe','trashingUser','trashedTime','teamDriveId','hasAugmentedPermissions',
         'keepForever', 'published', # revisions
         IgnoreCase = $false)]
-        [string[]]$ResultProperty = @('kind','id','name','mimeType','parents'),
+        [string[]]$Property = @('kind','id','name','mimeType','parents'),
 
         [string]$ResumeID,
 
@@ -161,7 +161,7 @@ function Set-GDriveItemContent {
         Write-Verbose "Constructed Metadata: $JsonProperty"
     }
     if ($UseMetadataFromFile -and -not $PSBoundParameters.ContainsKey('ID')) {
-        $FileMetadata = Get-Item $InFile
+        $FileMetadata = Get-Item ([Management.Automation.WildcardPattern]::Escape($InFile))
         $JsonProperty = '{{ "name": "{0}", "parents": ["{1}"], "modifiedTime": "{2}", "createdTime": "{3}" }}' -f 
                                 $FileMetadata.Name,
                                 ($ParentID -join '","'),
@@ -208,12 +208,12 @@ function Set-GDriveItemContent {
             Write-Verbose "Updating File $ID"
             # Patch instead of Put! docs are wrong? Put give 404
             $WebRequestParams.Method = 'Patch'
-            $WebRequestParams.Uri = "$($GDriveUploadUri)$($ID)?supportsAllDrives=true&uploadType=resumable&fields=$($ResultProperty -join ',')"
+            $WebRequestParams.Uri = "$($GDriveUploadUri)$($ID)?supportsAllDrives=true&uploadType=resumable&fields=$($Property -join ',')"
         }
         else {
             Write-Verbose "Creating New file"
             $WebRequestParams.Method = 'Post'
-            $WebRequestParams.Uri = "$($GDriveUploadUri)?supportsAllDrives=true&uploadType=resumable&fields=$($ResultProperty -join ',')"
+            $WebRequestParams.Uri = "$($GDriveUploadUri)?supportsAllDrives=true&uploadType=resumable&fields=$($Property -join ',')"
         }
         if($KeepRevisionForever) {
             $WebRequestParams.Uri = $WebRequestParams.Uri + "&keepRevisionForever=true"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # GMGoogleDrive
 Google Drive REST Api module for Powershell
+
+## Table of Contents
+
+- [GoogleDrive Setup](#googledrive-setup)
+- [Usage](#usage)
+- [Error Handling](#error-handling)
+- [Automate things](#automate-things)
+
+
 ### GoogleDrive Setup
 Google Drive is a free service for file storage files. In order to use this storage you need a Google (or Google Apps) user which will own the files, and a Google API client.
 1. Go to the [Google Developers console](https://console.developers.google.com/project) and create a new project.


### PR DESCRIPTION
Hi,


I added the following features to Add-GDriveItem and Set-GDriveItemContent
.PARAMETER ResultProperty
    List of properties that will be retured once upload is completed
.PARAMETER UseMetadataFromFile
    Uses the metadata (name, creation date and modification date) of the file provided in InFile
.PARAMETER KeepRevisionForever
    Set the flag that this revision of the file will be kept forever.

I had some issues with uploading files using Add-GDriveItem if the file size was lower than the chuck size. - fixed

In Find-GDriveItem I added an escape function to the query. To solve an issue with a & in the file name.


If there are any questions, please let me know.

I'm currently planning to add a function to work with google service accounts.