### PR TITLE
Fix notification mail

### DIFF
--- a/GMGoogleDrive/Public/GSheets/Export-GSheets.ps1
+++ b/GMGoogleDrive/Public/GSheets/Export-GSheets.ps1
@@ -63,8 +63,8 @@ function Export-GSheets {
         $FirstRun = $true
         $Values  = @()
         $requestParams = @{
-            AccessToken = $AccessToken 
-            SpreadsheetId = $SpreadsheetId 
+            AccessToken = $AccessToken
+            SpreadsheetId = $SpreadsheetId
         }
 
         if ($Append) {

--- a/GMGoogleDrive/Public/Item/Restore-GDriveItem.ps1
+++ b/GMGoogleDrive/Public/Item/Restore-GDriveItem.ps1
@@ -29,9 +29,6 @@ param(
     [string]$AccessToken
 )
 
-    $Headers = @{
-        "Authorization" = "Bearer $AccessToken"
-    }
     $Uri = '{0}{1}?supportsAllDrives=true' -f $GDriveUri, $ID
     Write-Verbose "URI: $Uri"
     if ($PSCmdlet.ShouldProcess($ID, "Restore Item from trash")) {

--- a/GMGoogleDrive/Public/Permission/Add-GDriveItemPermission.ps1
+++ b/GMGoogleDrive/Public/Permission/Add-GDriveItemPermission.ps1
@@ -79,7 +79,8 @@ param(
     [switch]$MoveToNewOwnersRoot,
     [switch]$TransferOwnership,
     [switch]$UseDomainAdminAccess,
-    [switch]$SendNotificationEmail,
+
+    [bool]$SendNotificationEmail = $true,
 
     [string]$EmailMessage,
 
@@ -95,11 +96,12 @@ param(
     if ($EmailMessage) {
         [void]$Params.Add('emailMessage={0}' -f [System.Net.WebUtility]::UrlEncode($EmailMessage))
     }
-    foreach ($k in 'enforceSingleParent','moveToNewOwnersRoot', 'sendNotificationEmail', 'transferOwnership', 'useDomainAdminAccess') {
+    foreach ($k in 'enforceSingleParent','moveToNewOwnersRoot', 'transferOwnership', 'useDomainAdminAccess') {
         if ($PSBoundParameters.ContainsKey($k)) {
             [void]$Params.Add('{0}=true' -f $k)
         }
     }
+    [void]$Params.Add('sendNotificationEmail={0}' -f $SendNotificationEmail)
     $Uri = '{0}{1}/permissions?supportsAllDrives=true&{2}' -f $GDriveUri, $ID, ($Params -join '&')
     Write-Verbose "URI: $Uri"
     $Body = @{

--- a/GMGoogleDrive/Public/Permission/Set-GDriveItemPermission.ps1
+++ b/GMGoogleDrive/Public/Permission/Set-GDriveItemPermission.ps1
@@ -41,7 +41,7 @@
     https://developers.google.com/drive/api/v3/ref-roles
 #>
 function Set-GDriveItemPermission {
-[CmdletBinding(DefaultParameterSetName='Add')]
+[CmdletBinding(DefaultParameterSetName='Add',SupportsShouldProcess=$true)]
 param(
     [Parameter(Mandatory, Position=0)]
     [string]$ID,
@@ -89,5 +89,7 @@ param(
         Headers = $Headers
         ContentType = "application/json; charset=utf-8"
     }
-    Invoke-RestMethod @requestParams -Method Patch -Body $JsonProperty @GDriveProxySettings
+    if ($PSCmdlet.ShouldProcess($ID, "Change permission")) {
+        Invoke-RestMethod @requestParams -Method Patch -Body $JsonProperty @GDriveProxySettings
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue with the `Add-GDriveItemPermission` function related to email notifications.

The `SendNotificationEmail` parameter was implemented as a switch parameter, which implicitly sets the value to `true`. Because `true` is also the default value by Google, users had no way to prevent notification emails from being sent.

To resolve this, the parameter type was changed to a boolean, allowing users to explicitly set `SendNotificationEmail` to `false`, as supported by the Google Drive API:
https://developers.google.com/workspace/drive/api/reference/rest/v3/permissions/create

+ small changes to fix some PSScriptAnalyzer findings