### PR TITLE
Add Get-GDriveFolderIdByPath function to resolve paths and dynamically create folders

### DIFF
--- a/GMGoogleDrive/GMGoogleDrive.psd1
+++ b/GMGoogleDrive/GMGoogleDrive.psd1
@@ -93,6 +93,7 @@ FunctionsToExport = @(
     'Set-GDriveItemContent',
     'Set-GDriveItemProperty',
     'Export-GDriveItemContent',
+    'Resolve-GDriveFolderIdByPath',
 
     'Get-GDriveItemPermissionList',
     'Get-GDriveItemPermission',

--- a/GMGoogleDrive/Public/Item/Find-GDriveItem.ps1
+++ b/GMGoogleDrive/Public/Item/Find-GDriveItem.ps1
@@ -12,7 +12,7 @@
 .PARAMETER DriveId
     ID of the shared drive to search
 .PARAMETER Corpora
-    Specifies a collection of items to which the query applies. Prefer user or drive to allDrives for efficiency. 
+    Specifies a collection of items to which the query applies. Prefer user or drive to allDrives for efficiency.
 .PARAMETER AllDriveItems
     Get result from all drives (inluding shared drives)
 .PARAMETER AllResults
@@ -68,13 +68,13 @@ param(
                     'sharedWithMeTime desc', 'starred desc', 'viewedByMeTime desc'
     )]
     [string[]]$OrderBy,
-    
+
     [ValidatePattern(
         '0A[0-9a-zA-Z-_]{13}9PVA',
         ErrorMessage="'{0}' is not a valid DriveID. DriveIDs must be 19 characters long, beginning with '0A' and ending with '9PVA'. (Pattern: '{1}')"
     )]
     [string]$DriveId,
-    
+
     [ValidateSet('user', 'domain', 'drive', 'allDrives')]
     [string]$Corpora,
 

--- a/GMGoogleDrive/Public/Item/Get-GDriveFolderIdByPath.ps1
+++ b/GMGoogleDrive/Public/Item/Get-GDriveFolderIdByPath.ps1
@@ -1,0 +1,112 @@
+<#
+.SYNOPSIS
+    Resolves a hierarchical folder path into a Google Drive folder ID
+.DESCRIPTION
+    Traverses a folder path element-by-element by querying the Google Drive API recursively. 
+    The function can either fail when a subfolder is missing or dynamically build out the 
+    directory structure on the fly.
+.PARAMETER Path
+    The structural string path of the target folder (e.g., "Test/ABC/123" or "Test\ABC\123"). 
+.PARAMETER AccessToken
+    Access Token for request
+.PARAMETER ParentId
+    An optional Google Drive Folder ID or Shared Drive ID to start the search from. 
+    Providing this optimizes performance by bypassing the global root-level search.
+.PARAMETER CreateIfNotExisting
+    If specified, the function will dynamically create any missing folders along the path 
+    rather than throwing an error.
+.EXAMPLE
+    $FolderId = Get-GDriveFolderIdByPath -Path "SharedDrive/Test/ABC" -AccessToken $MyToken
+    Resolves the ID for the folder "ABC" starting from the global root.
+.EXAMPLE
+    $FolderId = Get-GDriveFolderIdByPath -Path "Test\ABC\123" -AccessToken $MyToken -ParentId "0B-zZ...xyz" -CreateIfNotExisting
+    Starts searching inside the folder defined by ParentId. If "ABC" or "123" do not exist, they are created automatically.
+.OUTPUTS
+    System.String. Returns the alpha-numeric Google Drive ID of the target folder, or $null if the operation fails.
+.NOTES
+    - This function issues one API call per path depth level.
+#>
+function Get-GDriveFolderIdByPath {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AccessToken,
+
+        [string]$ParentId,
+
+        [switch]$CreateIfNotExisting
+    )
+
+    # Split the path across both / and \ and strip empty elements via the .Where() method
+    $Elements = ($Path -split '[/\\]').Where({ $_ })
+    
+    if ($Elements.Count -eq 0) {
+        Write-Error "The provided path is empty or invalid."
+        return $null
+    }
+
+    foreach ($Element in $Elements) {
+        # Escape single quotes in folder names to prevent Google Drive API query syntax errors
+        $EscapedName = $Element.Replace("'", "\'")
+
+        if ([string]::IsNullOrWhiteSpace($ParentId)) {
+            # Step 1: Search globally for the root folder or Shared Drive top-level directory
+            $Query = "name = '{0}' and mimeType = 'application/vnd.google-apps.folder' and trashed = false" -f $EscapedName
+        } else {
+            # Step 2: Target sub-folders strictly within the verified parent ID
+            $Query = "name = '{0}' and '{1}' in parents and mimeType = 'application/vnd.google-apps.folder' and trashed = false" -f $EscapedName, $ParentId
+        }
+
+        Write-Verbose "Querying for '$Element' using: $Query"
+        
+        # -AllDriveItems forces the API to look inside Shared Drives 
+        $SearchResult = Find-GDriveItem -AccessToken $AccessToken -Query $Query -AllDriveItems
+
+        # Validate if the API returned a valid file list object containing files
+        if ($null -eq $SearchResult -or $null -eq $SearchResult.files -or $SearchResult.files.Count -eq 0) {
+            
+            if ($CreateIfNotExisting) {
+                Write-Verbose "Creating folder for '$Element' (Parent: '$ParentId')"
+                
+                # Build parameter splatting table dynamically
+                $FolderParams = @{
+                    Name        = $Element
+                    AccessToken = $AccessToken
+                }
+                # Only append ParentID parameter if it actually exists
+                if (-not [string]::IsNullOrWhiteSpace($ParentId)) {
+                    $FolderParams['ParentID'] = $ParentId
+                }
+
+                # Create the folder safely
+                $NewFolder = New-GDriveFolder @FolderParams
+
+                # CRITICAL: Verify the folder was actually created successfully
+                if ($null -eq $NewFolder -or [string]::IsNullOrWhiteSpace($NewFolder.id)) {
+                    Write-Error "Failed to create folder '$Element' under parent '$ParentId'."
+                    return $null
+                }
+
+                $ParentId = $NewFolder.id
+            } else {
+                Write-Error "Failed to resolve path: Folder '$Element' was not found."
+                return $null
+            }
+
+        } else {
+            # If duplicate folder names exist at the same level, default to the first one returned
+            if ($SearchResult.files.Count -gt 1) {
+                Write-Warning "Multiple folders named '$Element' were found at this level. Proceeding with the first match."
+            }
+
+            # Update parent context to the current folder's ID for the next iteration
+            $ParentId = $SearchResult.files[0].id
+        }
+    }
+
+    # Return the final destination ID
+    return $ParentId
+}

--- a/GMGoogleDrive/Public/Item/Resolve-GDriveFolderIdByPath.ps1
+++ b/GMGoogleDrive/Public/Item/Resolve-GDriveFolderIdByPath.ps1
@@ -16,17 +16,17 @@
     If specified, the function will dynamically create any missing folders along the path 
     rather than throwing an error.
 .EXAMPLE
-    $FolderId = Get-GDriveFolderIdByPath -Path "SharedDrive/Test/ABC" -AccessToken $MyToken
+    $FolderId = Resolve-GDriveFolderIdByPath -Path "SharedDrive/Test/ABC" -AccessToken $MyToken
     Resolves the ID for the folder "ABC" starting from the global root.
 .EXAMPLE
-    $FolderId = Get-GDriveFolderIdByPath -Path "Test\ABC\123" -AccessToken $MyToken -ParentId "0B-zZ...xyz" -CreateIfNotExisting
+    $FolderId = Resolve-GDriveFolderIdByPath -Path "Test\ABC\123" -AccessToken $MyToken -ParentId "0B-zZ...xyz" -CreateIfNotExisting
     Starts searching inside the folder defined by ParentId. If "ABC" or "123" do not exist, they are created automatically.
 .OUTPUTS
     System.String. Returns the alpha-numeric Google Drive ID of the target folder, or $null if the operation fails.
 .NOTES
     - This function issues one API call per path depth level.
 #>
-function Get-GDriveFolderIdByPath {
+function Resolve-GDriveFolderIdByPath {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -48,16 +48,18 @@ function Get-GDriveFolderIdByPath {
         return $null
     }
 
+    $CurrentId = $ParentId
+
     foreach ($Element in $Elements) {
         # Escape single quotes in folder names to prevent Google Drive API query syntax errors
         $EscapedName = $Element.Replace("'", "\'")
 
-        if ([string]::IsNullOrWhiteSpace($ParentId)) {
+        if ([string]::IsNullOrWhiteSpace($CurrentId)) {
             # Step 1: Search globally for the root folder or Shared Drive top-level directory
             $Query = "name = '{0}' and mimeType = 'application/vnd.google-apps.folder' and trashed = false" -f $EscapedName
         } else {
             # Step 2: Target sub-folders strictly within the verified parent ID
-            $Query = "name = '{0}' and '{1}' in parents and mimeType = 'application/vnd.google-apps.folder' and trashed = false" -f $EscapedName, $ParentId
+            $Query = "name = '{0}' and '{1}' in parents and mimeType = 'application/vnd.google-apps.folder' and trashed = false" -f $EscapedName, $CurrentId
         }
 
         Write-Verbose "Querying for '$Element' using: $Query"
@@ -69,7 +71,7 @@ function Get-GDriveFolderIdByPath {
         if ($null -eq $SearchResult -or $null -eq $SearchResult.files -or $SearchResult.files.Count -eq 0) {
             
             if ($CreateIfNotExisting) {
-                Write-Verbose "Creating folder for '$Element' (Parent: '$ParentId')"
+                Write-Verbose "Creating folder for '$Element' (Parent: '$CurrentId')"
                 
                 # Build parameter splatting table dynamically
                 $FolderParams = @{
@@ -77,8 +79,8 @@ function Get-GDriveFolderIdByPath {
                     AccessToken = $AccessToken
                 }
                 # Only append ParentID parameter if it actually exists
-                if (-not [string]::IsNullOrWhiteSpace($ParentId)) {
-                    $FolderParams['ParentID'] = $ParentId
+                if (-not [string]::IsNullOrWhiteSpace($CurrentId)) {
+                    $FolderParams['ParentID'] = $CurrentId
                 }
 
                 # Create the folder safely
@@ -86,11 +88,11 @@ function Get-GDriveFolderIdByPath {
 
                 # CRITICAL: Verify the folder was actually created successfully
                 if ($null -eq $NewFolder -or [string]::IsNullOrWhiteSpace($NewFolder.id)) {
-                    Write-Error "Failed to create folder '$Element' under parent '$ParentId'."
+                    Write-Error "Failed to create folder '$Element' under parent '$CurrentId'."
                     return $null
                 }
 
-                $ParentId = $NewFolder.id
+                $CurrentId = $NewFolder.id
             } else {
                 Write-Error "Failed to resolve path: Folder '$Element' was not found."
                 return $null
@@ -103,10 +105,10 @@ function Get-GDriveFolderIdByPath {
             }
 
             # Update parent context to the current folder's ID for the next iteration
-            $ParentId = $SearchResult.files[0].id
+            $CurrentId = $SearchResult.files[0].id
         }
     }
 
     # Return the final destination ID
-    return $ParentId
+    return $CurrentId
 }

--- a/GMGoogleDrive/Public/Item/Resolve-GDriveFolderIdByPath.ps1
+++ b/GMGoogleDrive/Public/Item/Resolve-GDriveFolderIdByPath.ps1
@@ -27,7 +27,7 @@
     - This function issues one API call per path depth level.
 #>
 function Resolve-GDriveFolderIdByPath {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param (
         [Parameter(Mandatory = $true)]
         [string]$Path,
@@ -50,25 +50,33 @@ function Resolve-GDriveFolderIdByPath {
 
     $CurrentId = $ParentId
 
-    foreach ($Element in $Elements) {
-        # Escape single quotes in folder names to prevent Google Drive API query syntax errors
-        $EscapedName = $Element.Replace("'", "\'")
+    # Variable for recursive should process
+    $IsSimulatedPath = $false
 
-        if ([string]::IsNullOrWhiteSpace($CurrentId)) {
-            # Step 1: Search globally for the root folder or Shared Drive top-level directory
-            $Query = "name = '{0}' and mimeType = 'application/vnd.google-apps.folder' and trashed = false" -f $EscapedName
-        } else {
-            # Step 2: Target sub-folders strictly within the verified parent ID
-            $Query = "name = '{0}' and '{1}' in parents and mimeType = 'application/vnd.google-apps.folder' and trashed = false" -f $EscapedName, $CurrentId
+    foreach ($Element in $Elements) {
+
+        if (-not $isSimulatedPath) {
+
+            # Escape single quotes in folder names to prevent Google Drive API query syntax errors
+            $EscapedName = $Element.Replace("'", "\'")
+
+            if ([string]::IsNullOrWhiteSpace($CurrentId)) {
+                # Step 1: Search globally for the root folder or Shared Drive top-level directory
+                $Query = "name = '{0}' and mimeType = 'application/vnd.google-apps.folder' and trashed = false" -f $EscapedName
+            } else {
+                # Step 2: Target sub-folders strictly within the verified parent ID
+                $Query = "name = '{0}' and '{1}' in parents and mimeType = 'application/vnd.google-apps.folder' and trashed = false" -f $EscapedName, $CurrentId
+            }
+
+            Write-Verbose "Querying for '$Element' using: $Query"
+            
+            # -AllDriveItems forces the API to look inside Shared Drives 
+            $SearchResult = Find-GDriveItem -AccessToken $AccessToken -Query $Query -AllDriveItems
+
         }
 
-        Write-Verbose "Querying for '$Element' using: $Query"
-        
-        # -AllDriveItems forces the API to look inside Shared Drives 
-        $SearchResult = Find-GDriveItem -AccessToken $AccessToken -Query $Query -AllDriveItems
-
         # Validate if the API returned a valid file list object containing files
-        if ($null -eq $SearchResult -or $null -eq $SearchResult.files -or $SearchResult.files.Count -eq 0) {
+        if ($isSimulatedPath -or $null -eq $SearchResult -or $null -eq $SearchResult.files -or $SearchResult.files.Count -eq 0) {
             
             if ($CreateIfNotExisting) {
                 Write-Verbose "Creating folder for '$Element' (Parent: '$CurrentId')"
@@ -83,16 +91,26 @@ function Resolve-GDriveFolderIdByPath {
                     $FolderParams['ParentID'] = $CurrentId
                 }
 
-                # Create the folder safely
-                $NewFolder = New-GDriveFolder @FolderParams
+                if($PSCmdlet.ShouldProcess("Create new folder '$Element' under '$CurrentId'", $Element, "New-GDriveFolder")) {
 
-                # CRITICAL: Verify the folder was actually created successfully
-                if ($null -eq $NewFolder -or [string]::IsNullOrWhiteSpace($NewFolder.id)) {
-                    Write-Error "Failed to create folder '$Element' under parent '$CurrentId'."
-                    return $null
+                    # Create the folder
+                    $NewFolder = New-GDriveFolder @FolderParams
+
+                    # Verify the folder was actually created successfully
+                    if ($null -eq $NewFolder -or [string]::IsNullOrWhiteSpace($NewFolder.id)) {
+                        Write-Error "Failed to create folder '$Element' under parent '$CurrentId'."
+                        return $null
+                    }
+
+                    $CurrentId = $NewFolder.id
+
+                } else {
+
+                    $CurrentId = "DummyIdForElement-" + $Element
+                    $IsSimulatedPath = $true
+
                 }
 
-                $CurrentId = $NewFolder.id
             } else {
                 Write-Error "Failed to resolve path: Folder '$Element' was not found."
                 return $null

--- a/GMGoogleDrive/Public/Item/Resolve-GDriveFolderIdByPath.ps1
+++ b/GMGoogleDrive/Public/Item/Resolve-GDriveFolderIdByPath.ps1
@@ -2,18 +2,18 @@
 .SYNOPSIS
     Resolves a hierarchical folder path into a Google Drive folder ID
 .DESCRIPTION
-    Traverses a folder path element-by-element by querying the Google Drive API recursively. 
-    The function can either fail when a subfolder is missing or dynamically build out the 
+    Traverses a folder path element-by-element by querying the Google Drive API recursively.
+    The function can either fail when a subfolder is missing or dynamically build out the
     directory structure on the fly.
 .PARAMETER Path
-    The structural string path of the target folder (e.g., "Test/ABC/123" or "Test\ABC\123"). 
+    The structural string path of the target folder (e.g., "Test/ABC/123" or "Test\ABC\123").
 .PARAMETER AccessToken
     Access Token for request
 .PARAMETER ParentId
-    An optional Google Drive Folder ID or Shared Drive ID to start the search from. 
+    An optional Google Drive Folder ID or Shared Drive ID to start the search from.
     Providing this optimizes performance by bypassing the global root-level search.
 .PARAMETER CreateIfNotExisting
-    If specified, the function will dynamically create any missing folders along the path 
+    If specified, the function will dynamically create any missing folders along the path
     rather than throwing an error.
 .EXAMPLE
     $FolderId = Resolve-GDriveFolderIdByPath -Path "SharedDrive/Test/ABC" -AccessToken $MyToken
@@ -42,7 +42,7 @@ function Resolve-GDriveFolderIdByPath {
 
     # Split the path across both / and \ and strip empty elements via the .Where() method
     $Elements = ($Path -split '[/\\]').Where({ $_ })
-    
+
     if ($Elements.Count -eq 0) {
         Write-Error "The provided path is empty or invalid."
         return $null
@@ -69,18 +69,18 @@ function Resolve-GDriveFolderIdByPath {
             }
 
             Write-Verbose "Querying for '$Element' using: $Query"
-            
-            # -AllDriveItems forces the API to look inside Shared Drives 
+
+            # -AllDriveItems forces the API to look inside Shared Drives
             $SearchResult = Find-GDriveItem -AccessToken $AccessToken -Query $Query -AllDriveItems
 
         }
 
         # Validate if the API returned a valid file list object containing files
         if ($isSimulatedPath -or $null -eq $SearchResult -or $null -eq $SearchResult.files -or $SearchResult.files.Count -eq 0) {
-            
+
             if ($CreateIfNotExisting) {
                 Write-Verbose "Creating folder for '$Element' (Parent: '$CurrentId')"
-                
+
                 # Build parameter splatting table dynamically
                 $FolderParams = @{
                     Name        = $Element


### PR DESCRIPTION
This PR introduces a new helper function, `Get-GDriveFolderIdByPath`. Since Google Drive relies entirely on an ID-based architecture rather than a native file path system, resolving hierarchical paths or verifying nested folder structures typically requires a lot of boilerplate code.

This function bridges that gap by allowing users to interact with Google Drive folders using familiar path strings.

## Key Features

* handles both forward slashes (`/`) and backslashes (`\`)
* Includes a `-CreateIfNotExisting` switch. If any subfolder along the path is missing, the function will automatically create it on the fly
* Accepts an optional `-ParentId` to start in a specific subfolder or Shared Drive

## Why this is useful

In many automation workflows, developers only have a string path (e.g., from a local config file or synchronous folder mirroring). Manually chaining `Find-GDriveItem` for every folder depth level is cumbersome. This function encapsulates that entire logic into a single, reusable cmdlet.
